### PR TITLE
add autoupdate capability

### DIFF
--- a/templates/raspbian/resources/bin/autoupdate.sh
+++ b/templates/raspbian/resources/bin/autoupdate.sh
@@ -12,9 +12,14 @@ CONFIG_REL=$(/usr/bin/head -1 /cattlepi/base_relative_config)
 MATCH=0
 /usr/bin/cmp -s /tmp/current_config /cattlepi/config || MATCH=1
 if [ $MATCH -ne 0 ]; then
+    # add up to 550 seconds delay before rebooting (ie sleep(random(550)) in bash)
+    #   this should help in theory if you have a large number of devices 
+    #   and you are driving all of them off the default config 
+    sleep $(( RANDOM %= 550 ))
     set +e 
     /sbin/reboot -f 
-    if [ $? -ne 0]; then
+    if [ $? -ne 0 ]; then
+        # the reboot did not work. force it even more
         echo 1 > /proc/sys/kernel/sysrq
         echo b > /proc/sysrq-trigger        
     fi

--- a/templates/raspbian/resources/bin/autoupdate.sh
+++ b/templates/raspbian/resources/bin/autoupdate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+APIKEY=$(/usr/bin/head -1 /cattlepi/apikey)
+BASE=$(/usr/bin/head -1 /cattlepi/base)
+CONFIG_REL=$(/usr/bin/head -1 /cattlepi/base_relative_config)
+
+/usr/bin/curl -fsSL -H "Accept: application/json" \
+     -H "Content-Type: application/json" \
+     -H "X-Api-Key: $APIKEY" \
+     $BASE/$CONFIG_REL > /tmp/current_config
+
+MATCH=0
+/usr/bin/cmp -s /tmp/current_config /cattlepi/config || MATCH=1
+if [ $MATCH -ne 0 ]; then
+    set +e 
+    /sbin/reboot -f 
+    if [ $? -ne 0]; then
+        echo 1 > /proc/sys/kernel/sysrq
+        echo b > /proc/sysrq-trigger        
+    fi
+fi

--- a/templates/raspbian/resources/bin/bootstrap.sh
+++ b/templates/raspbian/resources/bin/bootstrap.sh
@@ -21,6 +21,20 @@ if [ $? -ne 0 ]; then
     done
 fi
 echo "-------------------------------------------------------"
+echo "adding the config watcher"
+echo "-------------------------------------------------------"
+/bin/cat /cattlepi/config | /usr/bin/jq -r .config.autoupdate | grep -q null
+if [ $? -ne 0 ]; then
+    AUTOUPDATE=$(/bin/cat /cattlepi/config | /usr/bin/jq -r .config.autoupdate)
+    if [ $AUTOUPDATE == "true" ]; then
+        # enable the autoupdate cron script used to detect the ip
+        # right now it's ran once every 10 minutes - could be made configurable if need arises
+cat <<'EOF' > /etc/cron.d/cattlepi_autoupdate
+*/10 * * * *   root    /etc/autoupdate.sh
+EOF
+    fi # $AUTOUPDATE == "true"
+fi
+echo "-------------------------------------------------------"
 echo "running user code if any"
 echo "-------------------------------------------------------"
 /bin/cat /cattlepi/config | /usr/bin/jq -r .usercode | /usr/bin/base64 -d > /tmp/usercode.sh

--- a/templates/raspbian/tasks/squashfs.yml
+++ b/templates/raspbian/tasks/squashfs.yml
@@ -24,6 +24,10 @@
     path: /tmp/squashfs/rootfs/etc/rc.local
     line: /usr/bin/nohup /etc/bootstrap.sh > /tmp/bootstrap.log 2>&1 &
     insertbefore: 'exit 0'
+- name: bring in the autoupdate script
+  shell: cp -R /tmp/resources/bin/autoupdate.sh /tmp/squashfs/rootfs/etc/autoupdate.sh
+- name: permissions on the autoupdate script
+  shell: chmod 0755 /tmp/squashfs/rootfs/etc/autoupdate.sh
 - name: clear fstab 
   shell: echo '' > /tmp/squashfs/rootfs/etc/fstab
 - lineinfile:


### PR DESCRIPTION
 add the autoupdate capability. addresses https://github.com/cattlepi/cattlepi/issues/16
if enabled via the config, a cronjob will pull the config once every 10 minutes and will reboot if the config change. you enable it by setting autoupdate=true in the config field of the device boot target. 

Example:
```
{
  "bootcode": "",
  "config": {
    "autoupdate": true,
    "ssh": {
      "pi": {
        "authorized_keys": [
          "<<your key here>>"
        ]
      }
    }
  },
  "initfs": {
    "md5sum": "c332711efbc42f35ae9a52d699bcdd07",
    "url": "https://api.cattlepi.com/images/global/raspbian-lite/2018-06-29/v6/initramfs.tgz"
  },
  "rootfs": {
    "md5sum": "0f8adafa2575a2685507452a3101ee26",
    "url": "https://api.cattlepi.com/images/global/raspbian-lite/2018-06-29/v6/rootfs.sqsh"
  },
  "usercode": ""
}
```

Basic tests performed and an image was build w/ this raspbian-lite/2018-06-29/v6
A few more tests need to be performed and the image will be promoted to the default image (and cattlepi.com images will be updated to list it)