### PR TITLE
Add check for existence of virtualenv before continuing to setup envi…

### DIFF
--- a/tools/util/setup_env.sh
+++ b/tools/util/setup_env.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 VENVDIR=$TOPDIR"/tools/venv"
 CFGDIR=$TOPDIR"/tools/cfg"
+VIRTUALENV=$(type -p virtualenv)
+
+if [[ -z "${VIRTUALENV}" ]]; then
+    echo "'virtualenv' is not installed on this system, can't continue..."
+    exit 1
+fi
 
 if [[ -r $VENVDIR/bin/activate ]]; then
     echo "environment already setup. skipping (make clean to force env rebuild)"
 else
     rm -rf $VENVDIR/*
-    virtualenv $VENVDIR
+    $VIRTUALENV $VENVDIR
     cp $CFGDIR"/requirements.txt" $VENVDIR"/"
     source $VENVDIR/bin/activate
     cd $VENVDIR && pip install -r requirements.txt
     deactivate
 fi
-


### PR DESCRIPTION
…ronment

This should fix #26 !

The gist is that if ```virtualenv``` doesn't exist on the system, we shouldn't go ahead and continue to install a bunch of things to the global python env.

Some testing:

*```virtualenv``` NOT installed*
```
~/programming/cattlepi $ pip uninstall virtualenv
Uninstalling virtualenv-16.0.0:
...
Proceed (y/n)? y
  Successfully uninstalled virtualenv-16.0.0

~/programming/cattlepi $ make envsetup
make: envsetup
export TOPDIR=/Users/zac/programming/cattlepi/ && /Users/zac/programming/cattlepi/tools/util/setup_env.sh
'virtualenv' is not installed on this system, can't continue...
make: *** [envsetup] Error 1
```

*```virtualenv``` installed*
```
~/programming/cattlepi $ pip install virtualenv
Collecting virtualenv
  Using cached https://files.pythonhosted.org/packages/b6/30/96a02b2287098b23b875bc8c2f58071c35d2efe84f747b64d523721dc2b5/virtualenv-16.0.0-py2.py3-none-any.whl
Installing collected packages: virtualenv
Successfully installed virtualenv-16.0.0

~/programming/cattlepi $ make envsetup
make: envsetup
export TOPDIR=/Users/zac/programming/cattlepi/ && /Users/zac/programming/cattlepi/tools/util/setup_env.sh
New python executable in /Users/zac/programming/cattlepi/tools/venv/bin/python2.7
Also creating executable in /Users/zac/programming/cattlepi/tools/venv/bin/python
Installing setuptools, pip, wheel...done.
Collecting ansible==2.5.1 (from -r requirements.txt (line 1))
Collecting asn1crypto==0.24.0 (from -r requirements.txt (line 2))
...
```
