### PR TITLE
fix timing condition in myenv.sh

### DIFF
--- a/bin/myenv.sh
+++ b/bin/myenv.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 # master build script
 SELFDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export TOPDIR=$(dirname $SELFDIR)
-export BUILDDIR=$TOPDIR"/builder/"$(date +"%d_%b_%Y_%H_%M_%S_%Z")
-export BUILDDIRLATEST=$TOPDIR"/builder/latest"
-export UTILDIR=$TOPDIR"/tools/util"
+
+CTOPDIR=$(dirname $SELFDIR)
+TOPDIR=${TOPDIR:-$CTOPDIR}
+export TOPDIR
+
+CBUILDDIR=$TOPDIR"/builder/"$(date +"%d_%b_%Y_%H_%M_%S_%Z")
+BUILDDIR=${BUILDDIR:-$CBUILDDIR}
+export BUILDDIR
+
+CBUILDDIRLATEST=$TOPDIR"/builder/latest"
+BUILDDIRLATEST=${BUILDDIRLATEST:-$CBUILDDIRLATEST}
+export BUILDDIRLATEST
+
+CUTILDIR=$TOPDIR"/tools/util"
+UTILDIR=${UTILDIR:-$CUTILDIR}
+export UTILDIR
+
 $UTILDIR/recipe_runner.sh "$@"


### PR DESCRIPTION
fix condition in which recipes that included other recipes would fail if BUILDDIR (based on time) was different for the included recipe vs the parent recipe (usually by 1 sec)

right now, we use what' define (and previously has been exported) if it's already there. this way, all recipes that were includes leverage the same env vars (which was by design, but did not happen in edge cases :|)