### PR TITLE
[WIP] Enable wireless functionality in initramfs if wpa_supplicant exists

### DIFF
--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/hooks/cattlesupport
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/hooks/cattlesupport
@@ -39,6 +39,11 @@ copy_exec /sbin/mkfs.minix /bin
 copy_exec /sbin/mkfs.msdos /bin
 copy_exec /sbin/mkfs.vfat /bin
 
+# things needed for wireless support
+manual_add_modules brcmfmac
+copy_exec /sbin/wpa_supplicant
+copy_exec /sbin/wpa_cli
+
 # make dns and ssl great again
 cp -a /etc/ssl ${DESTDIR}/etc/ssl
 mkdir -p ${DESTDIR}/usr/share/

--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
@@ -355,3 +355,62 @@ cattlepi_build_root_filesystem()
     echo $CATTLEPI_BASE > "${rootmnt}/cattlepi/base"
     echo "boot/${CATTLEPI_ID}/config" > "${rootmnt}/cattlepi/base_relative_config"
 }
+
+cattlepi_bring_up_wlan() {
+    interface="${1:-wlan0}"
+    wait_limit="30"
+    online=false
+
+    modprobe brcmfmac
+
+    echo "Bringing up wlan0"
+
+    if [ ! -x "/sbin/wpa_supplicant" ]; then
+        echo "/sbin/wpa_supplicant doesn't exist, exiting wlan config"
+        return 1
+    fi
+
+    echo "Starting wireless connection"
+    /sbin/wpa_supplicant  -i"${interface}" -c/etc/wpa_supplicant/wpa_supplicant.conf -P/run/initram-wpa_supplicant.pid -B -f /tmp/wpa_supplicant.log
+
+    echo "Waiting for wirelss connection for ${wait_limit} seconds"
+    while [ $wait_limit -ge 0 ]; do
+        wpa_status=$(/sbin/wpa_cli -i$interface status | grep wpa_state)
+        if [ "${wpa_status}" == "wpa_state=COMPLETED" ]; then
+            echo "${interface} online"
+            online=true
+            break
+        fi
+
+        sleep 1
+        printf "." # omit the newline
+        wait_limit=$((wait_limit - 1))
+    done
+
+    if [ "${online}" != true ]; then
+        echo "${interface} offline"
+        return 1
+    fi
+
+    # Borrow a bit of code from configure_networking for this specific
+    # interface rather than sourcing from cmdline ip options
+    for ROUNDTTT in 2 3 4 6 9 16 25 36 64 100; do
+		# The NIC is to be configured if this file does not exist.
+		# Ip-Config tries to create this file and when it succeds
+		# creating the file, ipconfig is not run again.
+		for x in /run/net-"${interface}".conf ; do
+			[ -e "$x" ] && break 2
+		done
+
+		ipconfig -t ${ROUNDTTT} "${interface}"
+	done
+
+	# source ipconfig output
+	if [ -n "${interface}" ]; then
+		# source specific bootdevice
+		. /run/net-${interface}.conf
+	else
+        echo "Unable to get ip config for ${interface}"
+        return 1
+	fi
+}

--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-premount/netup
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-premount/netup
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PREREQ=""
+PREREQ="udev"
 
 prereqs()
 {
@@ -17,5 +17,12 @@ esac
 . /scripts/functions
 . /scripts/cattlepi-base/helpers
 
-set -x 
+set -x
+
+# If we have a wpa supplicant, try to set up wireless
+if [ -r /etc/wpa_supplicant/wpa_supplicant.conf ]; then
+    cattlepi_bring_up_wlan && exit 0
+fi
+
+# If setting up wireless doesn't work, fall back to wired
 configure_networking


### PR DESCRIPTION
This is the first step for #17 .  This first step enables wireless in the initramfs if a `wpa_supplicant.conf` exists.  By default `wpa_supplicant` is able to choose from multiple wireless networks and connect to the network in range.  You are also able to give priority order to the networks in the .conf file. 

This is a pretty simple pull request and borrows a little bit of code from the `configure_networking` function.  I debated on using it directly but that requires passing parameters in `cmdline`.  I want to be able to fall back to wired networking so this enables us to do that without changing the rest of our code.

Stage 2 for wireless functionality is a pretty small lift and involves pulling down the conf file, injecting it into the image as well as making it available for initramfs on the next boot.

This is WIP; testing in progress.  (Apologies for the delay, having a baby is hard)