### PR TITLE
rebuild index when autobuilding images

### DIFF
--- a/tools/autobuild/build_and_publish.sh
+++ b/tools/autobuild/build_and_publish.sh
@@ -116,3 +116,5 @@ do
     RECIPE="raspbian_s3_upload" run_recipe
 done
 
+# now rebuild the index which lists all the autobuild images
+RECIPE="raspbian_s3_build_index" run_recipe


### PR DESCRIPTION
right now you have to manually rebuild the index. this makes it automatic and it happens each time an autobuild happens.