### PR TITLE
try to fix apt race conditions (ansible tasks)

### DIFF
--- a/templates/raspbian_cattlepi/tasks/update_software.yml
+++ b/templates/raspbian_cattlepi/tasks/update_software.yml
@@ -1,10 +1,18 @@
+- name: update cache
+  apt:
+    update_cache: yes
+  retries: 3
+  delay: 30
+  register: result
+  until: result is succeeded
+  failed_when: result is failure
 - name: install packages
   apt:
-    name: "{{ item }}"
-    update_cache: yes
+    name: "{{ packages }}"
     force: yes
     state: latest
-  with_items:
+  vars:
+    packages:
     - vim
     - busybox
     - initramfs-tools
@@ -14,6 +22,11 @@
     - jq
     - ufw
     - pv
+  retries: 3
+  delay: 30
+  register: result
+  until: result is succeeded
+  failed_when: result is failure
 - name: disable swap
   command: dphys-swapfile swapoff
 - name: disable swap - make sure if does not come back
@@ -25,3 +38,8 @@
 - name: upgrade packages and dist
   apt:
     upgrade: full
+  retries: 3
+  delay: 30
+  register: result
+  until: result is succeeded
+  failed_when: result is failure

--- a/tools/cfg/requirements.txt
+++ b/tools/cfg/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.0
+ansible==2.7.6
 asn1crypto==0.24.0
 awscli==1.16.31
 bcrypt==3.1.4

--- a/tools/cfg/requirements.txt
+++ b/tools/cfg/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.7.6
+ansible==2.7.0
 asn1crypto==0.24.0
 awscli==1.16.31
 bcrypt==3.1.4


### PR DESCRIPTION
observed during the autobuild.
happens sporadically, but around 40% of cases. 
seems that the apt task is not releasing the apt lock quickly enough? right now just putting retries in place and trying with a slightly newer ansible version. 