### PR TITLE
fix rebuild issue (it was reusing the old cpio if that was present)

### DIFF
--- a/templates/raspbian_cattlepi/tasks/initramfs.yml.mustache
+++ b/templates/raspbian_cattlepi/tasks/initramfs.yml.mustache
@@ -34,6 +34,8 @@
   shell: /tmp/resources/bin/build_union_fs.sh
 - name: bring in the cattlepi initramfs script
   shell: cp -R /tmp/resources/usr /
+- name: bring in the rest of boot
+  shell: /bin/cp -R /boot/* /tmp/initramfs/
 - file:
     path: /tmp/initramfs/cattleinit.cpio
     state: absent
@@ -41,8 +43,6 @@
   shell: mkinitramfs -v -o /tmp/initramfs/cattleinit.cpio
 - name: set initramfs permissions
   shell: chmod 0755 /tmp/initramfs/cattleinit.cpio
-- name: bring in the rest of boot
-  shell: /bin/cp -R /boot/* /tmp/initramfs/
 - file:
     path: /tmp/initramfs/cattlepi
     state: absent


### PR DESCRIPTION
normally when built on clean we don't have this issue (since there is not cattleinit.cpio under boot/)
when we build with a cattlepi_stock image though (that was booted/provisioned using cattlepi) we do have the cpio archive and we are basically stuck with the outdated version.
it works most of the times because we don't change the init that ofter - but when we do + use the stock recipe (like in the CI and autobuild cases) we basically have the old one cpio and out changes don't make it in. 
(this was caught not when the recipe changed but when the kernel version got changed and the kernel under boot has issues finding the libs in the ramdisk - because it was running with the old one and it was not finding the paths)