### PR TITLE
defer loading the kernel module for wireless

### DIFF
--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
@@ -405,14 +405,13 @@ cattlepi_bring_up_wlan() {
     wait_limit="30"
     online=false
 
-    modprobe brcmfmac
-
-    echo "Bringing up wlan0"
-
     if [ ! -x "/sbin/wpa_supplicant" ]; then
         echo "/sbin/wpa_supplicant doesn't exist, exiting wlan config"
         return 1
     fi
+    
+    echo "Bringing up wlan0"
+    modprobe brcmfmac
 
     echo "Starting wireless connection"
     # Explicitly use /run/wpa_supplicant as the location of the control


### PR DESCRIPTION
if the config for the wpa supplicant is not present right now we still load the module which in turn will make the wireless network adapter to show up and the configure_networking bit will spin trying to configure it.
right now, try to bypass loading it (and only load it if it looks like we may need it)