### PR TITLE
remove wpa initramfs

### DIFF
--- a/templates/raspbian_cattlepi/resources/bin/hard_reboot.sh
+++ b/templates/raspbian_cattlepi/resources/bin/hard_reboot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# needs to be root
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root"
+   exit 1
+fi
+echo b >/proc/sysrq-trigger
+

--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/hooks/cattlesupport
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/hooks/cattlesupport
@@ -40,22 +40,11 @@ copy_exec /sbin/mkfs.msdos /bin
 copy_exec /sbin/mkfs.vfat /bin
 copy_exec /sbin/partprobe /bin
 
-# things needed for wireless support
-manual_add_modules brcmfmac
-manual_add_modules brcmutil
-manual_add_modules cfg80211
-copy_exec /sbin/wpa_supplicant
-copy_exec /sbin/wpa_cli
-
 # make dns and ssl great again
 cp -a /etc/ssl ${DESTDIR}/etc/ssl
 mkdir -p ${DESTDIR}/usr/share/
 echo "nameserver 8.8.8.8" > ${DESTDIR}/etc/resolv.conf
 cp -a /usr/share/ca-certificates ${DESTDIR}/usr/share/
 cp -a /lib/arm-linux-gnueabihf/libnss_dns* ${DESTDIR}/lib/arm-linux-gnueabihf/
-# manual_add_modules doesn't add any .txt files, only the .bin files.
-# These .txt files are needed by the firmware binaries.
-# https://www.raspberrypi.org/forums/viewtopic.php?t=225906
-cp -a /lib/firmware/brcm/*.txt ${DESTDIR}/lib/firmware/brcm/
 
 exit 0

--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
@@ -330,15 +330,6 @@ cattlepi_build_root_filesystem()
     cattlepi_find_params
     modprobe squashfs
     modprobe fuse
-    sleep 1
-    
-    # debug check for modules 
-    lsmod
-    sleep 1
-    
-    #debug check for loopback
-    ls -l /dev/loop*
-    sleep 1
 
     # figure out what rootfs squashed file we'll be using
     local target_rootsfs=$(jq -r ".rootfs.md5sum" "${CATTLEPI_DIR}/config")

--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-base/helpers
@@ -368,11 +368,6 @@ cattlepi_build_root_filesystem()
     echo "boot/${CATTLEPI_ID}/config" > "${rootmnt}/cattlepi/base_relative_config"
 }
 
-cattlepi_unload_wpa_supplicant_if_not_needed() {
-    rmmod brcmfmac
-    rmmod brcmutil
-    rmmod cfg80211
-}
 
 cattlepi_handle_wpa_supplicant() {
     cattlepi_fetch_update_config
@@ -403,70 +398,6 @@ cattlepi_handle_wpa_supplicant() {
         /bin/sync
         echo b >/proc/sysrq-trigger
     fi
-}
-
-cattlepi_bring_up_wlan() {
-    interface="${1:-wlan0}"
-    wpa_supplicant_location="${2:-${CATTLEPI_DIR}/wpa_supplicant.conf}"
-    wait_limit="30"
-    online=false
-
-    if [ ! -x "/sbin/wpa_supplicant" ]; then
-        echo "/sbin/wpa_supplicant doesn't exist, exiting wlan config"
-        return 1
-    fi
-    
-    echo "Bringing up wlan0"
-    modprobe brcmfmac
-
-    echo "Starting wireless connection"
-    # Explicitly use /run/wpa_supplicant as the location of the control
-    # interface for initramfs.
-    if ! /sbin/wpa_supplicant  -Dnl80211 -dd -i"${interface}" -C /run/wpa_supplicant/ -c"${wpa_supplicant_location}" -P/run/initram-wpa_supplicant.pid -B; then
-        echo "Unable to run wpa_supplicant, exiting wlan config"
-        return 1
-    fi
-
-    echo "Waiting for wirelss connection for ${wait_limit} seconds"
-    while [ $wait_limit -ge 0 ]; do
-        wpa_status=$(/sbin/wpa_cli -i$interface -p /run/wpa_supplicant/ status | grep wpa_state)
-        if [ "${wpa_status}" == "wpa_state=COMPLETED" ]; then
-            echo "${interface} online"
-            online=true
-            break
-        fi
-
-        sleep 1
-        printf "." # omit the newline
-        wait_limit=$((wait_limit - 1))
-    done
-
-    if [ "${online}" != true ]; then
-        echo "${interface} offline"
-        return 1
-    fi
-
-    # Borrow a bit of code from configure_networking for this specific
-    # interface rather than sourcing from cmdline ip options
-    for ROUNDTTT in 2 4 12; do
-		# The NIC is to be configured if this file does not exist.
-		# Ip-Config tries to create this file and when it succeds
-		# creating the file, ipconfig is not run again.
-		for x in /run/net-"${interface}".conf ; do
-			[ -e "$x" ] && break 2
-		done
-
-		ipconfig -t ${ROUNDTTT} "${interface}"
-	done
-
-	# source ipconfig output
-	if [ -n "${interface}" ]; then
-		# source specific bootdevice
-		. /run/net-${interface}.conf
-	else
-        echo "Unable to get ip config for ${interface}"
-        return 1
-	fi
 }
 
 cattlepi_sdmount() {

--- a/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-premount/netup
+++ b/templates/raspbian_cattlepi/resources/usr/share/initramfs-tools/scripts/cattlepi-premount/netup
@@ -24,14 +24,5 @@ cattlepi_find_params
 echo "cattlepi - sdmount"
 cattlepi_sdmount
 
-echo "preprocess wpa supplicant"
-cattlepi_unload_wpa_supplicant_if_not_needed
-
-# echo "wpa supplicant initialization"
-# # If we have a wpa supplicant, try to set up wireless
-# if [ -r "${CATTLEPI_DIR}/wpa_supplicant.conf" ]; then
-#     cattlepi_bring_up_wlan && exit 0
-# fi
-
 # If setting up wireless doesn't work, fall back to wired
 configure_networking


### PR DESCRIPTION
something probably changed in the image or the dependency closure but the wpa does no longer work in the initramfs (if removed it continues to work in raspbian).
removing this from initramfs since the only effect it has now is to slow down boot _and_ to make it not work once the full os comes up.