### PR TITLE
stamp autobuild version in image to make it easier to identify which …

### DIFF
--- a/templates/raspbian_cattlepi/resources/bin/release_version.sh.mustache
+++ b/templates/raspbian_cattlepi/resources/bin/release_version.sh.mustache
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "{{CATTLEPI_BUILDER_AUTOBUILD_ID}}"

--- a/tools/cfg/defaults
+++ b/tools/cfg/defaults
@@ -19,6 +19,7 @@ CATTLEPI_APIKEY=${CATTLEPI_APIKEY:-deadbeef}
 CATTLEPI_LOCALAPI=${CATTLEPI_LOCALAPI:-192.168.1.166:4567}
 CATTLEPI_BUILDER_SUPPORT=${CATTLEPI_BUILDER_SUPPORT:-https://github.com/cattlepi/cattlepi-builder-support.git}
 CATTLEPI_BUILDER_SUPPORT_TAG=${CATTLEPI_BUILDER_SUPPORT_TAG:-dd804fa47638f5183a3ebede390a48c613f83663}
+CATTLEPI_BUILDER_AUTOBUILD_ID=${AB_ID:-$(date +%Y_%m_%d_%H%M%S)}
 
 # settings for the s3 upload of images - update to your own if you want to upload the images to AWS S3
 #   you also need to have your credentials configured through  ~/.aws/credentials or other mechanism supported by


### PR DESCRIPTION
…image is currently running.

add separate executable to make this more manageable